### PR TITLE
Fix for solutions not having .git folder when searching root folder

### DIFF
--- a/src/MEF/WorkspaceRootNode.cs
+++ b/src/MEF/WorkspaceRootNode.cs
@@ -153,6 +153,13 @@ namespace WorkspaceFiles
 
             DirectoryInfo currentRoot = new(_solutionDir);
 
+            if (currentRoot == null)
+            {
+                return false;
+            }
+
+            solRoot = currentRoot;
+
             while (currentRoot != null)
             {
                 var dotGit = Path.Combine(currentRoot.FullName, ".git");


### PR DESCRIPTION
If there was no .git folder in the opened solution, the solRoot variable in the TryGetRoot function would out null even though the function returned true. Before entering the loop made for searching for the first .git folder, by assigning the folder where the solution is located as solRoot, it was ensured that it would work in solutions that do not contain a .git folder. If .git folder already exists, the folder containing it will be returned as before.