### PR TITLE
#44 - Fixes Open in VS Code with path names that contain spaces

### DIFF
--- a/src/Commands/OpenInVsCodeCommand.cs
+++ b/src/Commands/OpenInVsCodeCommand.cs
@@ -16,7 +16,7 @@ namespace WorkspaceFiles
             var start = new ProcessStartInfo()
             {
                 FileName = $"cmd.exe",
-                Arguments = $"/C code {args}",
+                Arguments = $"/C code \"{args}\"",
                 CreateNoWindow = true,
                 UseShellExecute = false,
                 WindowStyle = ProcessWindowStyle.Hidden,


### PR DESCRIPTION
Add quotes around VS Code Process Start command.
Fixes #44 