### PR TITLE
Use Console icon for "Open in Terminal" command

### DIFF
--- a/src/VSCommandTable.vsct
+++ b/src/VSCommandTable.vsct
@@ -95,7 +95,7 @@
 
       <Button guid="WorkspaceFiles" id="OpenInTerminal" priority="0x0125" type="Button">
         <Parent guid="WorkspaceFiles" id="RootOpenGroup" />
-        <Icon guid="ImageCatalogGuid" id="Open" />
+        <Icon guid="ImageCatalogGuid" id="Console" />
         <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>&amp;Open in Terminal</ButtonText>


### PR DESCRIPTION
Changes the icon from Open to Console to avoid having identical icons next to each other and to align with the icon used elsewhere for this action.

<img width="569" height="268" alt="image" src="https://github.com/user-attachments/assets/dc289e77-9682-4f05-90de-7e774c13fc21" />
