### PR TITLE
guarding the dorny/test-reporter step against forked PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Report test results
       uses: dorny/test-reporter@v1
-      if: always()
+      if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
       with:
         name: Test Results
         path: '**/test-results.trx'


### PR DESCRIPTION
otherwise the build fails - see #58 and #59