### PR TITLE
fix #52 - community toolkit dll is not copied to output

### DIFF
--- a/WorkspaceFiles.slnx
+++ b/WorkspaceFiles.slnx
@@ -5,7 +5,7 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
-  <Project Path="src/WorkspaceFiles.csproj">
+  <Project Path="src/WorkspaceFiles.csproj" Id="91446405-eabe-46d6-9eb9-505a14b74de0">
     <Platform Solution="*|arm64" Project="arm64" />
     <Platform Solution="*|x86" Project="x86" />
   </Project>

--- a/src/WorkspaceFiles.csproj
+++ b/src/WorkspaceFiles.csproj
@@ -134,9 +134,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Community.VisualStudio.VSCT" Version="16.0.29.6" PrivateAssets="all" />
-    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.549" ExcludeAssets="Runtime">
-      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Community.VisualStudio.Toolkit.17" Version="17.0.549" />
     <PackageReference Include="MAB.DotIgnore">
       <Version>3.0.2</Version>
     </PackageReference>


### PR DESCRIPTION
fix #52 - community toolkit dll is not copied to output but is refrenced in code.

This is how the community toolkit is referenced when installed in a new project :

<img width="1155" height="593" alt="image" src="https://github.com/user-attachments/assets/fe60eb3a-75cb-4d6d-8b6c-d6693385f62f" />
