### PR TITLE
Fix #51 - add a .git file detector

### DIFF
--- a/WorkspaceFiles.slnx
+++ b/WorkspaceFiles.slnx
@@ -5,7 +5,7 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
-  <Project Path="src/WorkspaceFiles.csproj">
+  <Project Path="src/WorkspaceFiles.csproj" Id="91446405-eabe-46d6-9eb9-505a14b74de0">
     <Platform Solution="*|arm64" Project="arm64" />
     <Platform Solution="*|x86" Project="x86" />
   </Project>

--- a/src/MEF/WorkspaceRootNode.cs
+++ b/src/MEF/WorkspaceRootNode.cs
@@ -11,6 +11,7 @@ using MAB.DotIgnore;
 using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
+using WorkspaceFiles.Services;
 
 namespace WorkspaceFiles
 {
@@ -330,9 +331,10 @@ namespace WorkspaceFiles
 
             while (currentRoot != null && depth < maxDepth)
             {
-                var dotGit = Path.Combine(currentRoot.FullName, ".git");
-
-                if (Directory.Exists(dotGit))
+                // A Git root can be marked by either a .git directory (main worktree)
+                // or a .git file (linked worktree). See GitRepositoryDetector docs
+                // and https://git-scm.com/docs/git-worktree#_details.
+                if (GitRepositoryDetector.HasGitMarker(currentRoot.FullName))
                 {
                     solRoot = currentRoot;
                     // Cache the result for future use

--- a/src/Services/GitRepositoryDetector.cs
+++ b/src/Services/GitRepositoryDetector.cs
@@ -1,0 +1,58 @@
+using System.IO;
+
+namespace WorkspaceFiles.Services
+{
+    /// <summary>
+    /// Detects Git repository roots for regular repositories and linked worktrees.
+    /// In linked worktrees, the <c>.git</c> entry is a file that points to the
+    /// worktree metadata location instead of a directory.
+    /// See: https://git-scm.com/docs/git-worktree#_details
+    /// </summary>
+    internal static class GitRepositoryDetector
+    {
+        /// <summary>
+        /// Traverses parent directories until it finds a Git marker.
+        /// </summary>
+        public static bool TryFindGitRoot(string path, out string repoRoot)
+        {
+            repoRoot = null;
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            var current = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
+
+            while (!string.IsNullOrEmpty(current))
+            {
+                if (HasGitMarker(current))
+                {
+                    repoRoot = current;
+                    return true;
+                }
+
+                current = Path.GetDirectoryName(current);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether a directory contains a Git marker.
+        /// The marker can be either a <c>.git</c> directory (main worktree)
+        /// or a <c>.git</c> file (linked worktree).
+        /// See: https://git-scm.com/docs/git-worktree#_details
+        /// </summary>
+        public static bool HasGitMarker(string directoryPath)
+        {
+            if (string.IsNullOrWhiteSpace(directoryPath))
+            {
+                return false;
+            }
+
+            var dotGitPath = Path.Combine(directoryPath, ".git");
+            return Directory.Exists(dotGitPath) || File.Exists(dotGitPath);
+        }
+    }
+}

--- a/src/Services/GitStatusService.cs
+++ b/src/Services/GitStatusService.cs
@@ -247,19 +247,7 @@ namespace WorkspaceFiles.Services
 
         private static string FindGitRoot(string path)
         {
-            var current = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
-
-            while (!string.IsNullOrEmpty(current))
-            {
-                if (Directory.Exists(Path.Combine(current, ".git")))
-                {
-                    return current;
-                }
-
-                current = Path.GetDirectoryName(current);
-            }
-
-            return null;
+            return GitRepositoryDetector.TryFindGitRoot(path, out var repoRoot) ? repoRoot : null;
         }
 
         private static bool IsRefreshRequired(string repoRoot)

--- a/src/WorkspaceFiles.csproj
+++ b/src/WorkspaceFiles.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Relationships.cs" />
     <Compile Include="MEF\WorkspaceItemInvocationController.cs" />
+    <Compile Include="Services\GitRepositoryDetector.cs" />
     <Compile Include="Services\GitStatusService.cs" />
     <Compile Include="WorkspaceFilesPackage.cs" />
     <Compile Include="source.extension.cs">

--- a/test/WorkspaceFiles.Test/GitRepositoryDetectorTests.cs
+++ b/test/WorkspaceFiles.Test/GitRepositoryDetectorTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WorkspaceFiles.Services;
+
+namespace WorkspaceFiles.Test
+{
+    [TestClass]
+    public class GitRepositoryDetectorTests
+    {
+        [TestMethod]
+        public void WhenDirectoryContainsGitFolderThenHasGitMarkerReturnsTrue()
+        {
+            var path = CreateTempDirectory();
+            Directory.CreateDirectory(Path.Combine(path, ".git"));
+
+            var hasGitMarker = GitRepositoryDetector.HasGitMarker(path);
+
+            Assert.IsTrue(hasGitMarker);
+        }
+
+        [TestMethod]
+        public void WhenDirectoryContainsGitFileThenHasGitMarkerReturnsTrue()
+        {
+            var path = CreateTempDirectory();
+            File.WriteAllText(Path.Combine(path, ".git"), "gitdir: D:/repo/.git/worktrees/dev");
+
+            var hasGitMarker = GitRepositoryDetector.HasGitMarker(path);
+
+            Assert.IsTrue(hasGitMarker);
+        }
+
+        [TestMethod]
+        public void WhenDirectoryDoesNotContainGitMarkerThenHasGitMarkerReturnsFalse()
+        {
+            var path = CreateTempDirectory();
+
+            var hasGitMarker = GitRepositoryDetector.HasGitMarker(path);
+
+            Assert.IsFalse(hasGitMarker);
+        }
+
+        [TestMethod]
+        public void WhenDirectoryPathIsNullThenHasGitMarkerReturnsFalse()
+        {
+            var hasGitMarker = GitRepositoryDetector.HasGitMarker(null);
+
+            Assert.IsFalse(hasGitMarker);
+        }
+
+        [TestMethod]
+        public void WhenDirectoryPathIsWhitespaceThenHasGitMarkerReturnsFalse()
+        {
+            var hasGitMarker = GitRepositoryDetector.HasGitMarker(" ");
+
+            Assert.IsFalse(hasGitMarker);
+        }
+
+        private static string CreateTempDirectory()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "WorkspaceFilesTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+    }
+}

--- a/test/WorkspaceFiles.Test/GitStatusServiceTests.cs
+++ b/test/WorkspaceFiles.Test/GitStatusServiceTests.cs
@@ -122,6 +122,51 @@ namespace WorkspaceFiles.Test
             Assert.AreEqual(0, GetRepoLastRefreshCount());
         }
 
+        [TestMethod]
+        public void WhenRepoContainsGitDirectoryThenTryFindGitRootReturnsRepoRoot()
+        {
+            var repoRoot = CreateTempDirectory();
+            var nestedDirectory = Directory.CreateDirectory(Path.Combine(repoRoot, "src", "nested"));
+            Directory.CreateDirectory(Path.Combine(repoRoot, ".git"));
+
+            var found = GitRepositoryDetector.TryFindGitRoot(nestedDirectory.FullName, out var resolvedRoot);
+
+            Assert.IsTrue(found);
+            Assert.AreEqual(Path.GetFullPath(repoRoot), Path.GetFullPath(resolvedRoot));
+        }
+
+        [TestMethod]
+        public void WhenRepoContainsGitFileThenTryFindGitRootReturnsRepoRoot()
+        {
+            var repoRoot = CreateTempDirectory();
+            var nestedDirectory = Directory.CreateDirectory(Path.Combine(repoRoot, "worktrees", "dev"));
+            File.WriteAllText(Path.Combine(repoRoot, ".git"), "gitdir: D:/repo/.git/worktrees/dev");
+
+            var found = GitRepositoryDetector.TryFindGitRoot(nestedDirectory.FullName, out var resolvedRoot);
+
+            Assert.IsTrue(found);
+            Assert.AreEqual(Path.GetFullPath(repoRoot), Path.GetFullPath(resolvedRoot));
+        }
+
+        [TestMethod]
+        public void WhenRepoMarkerIsMissingThenTryFindGitRootReturnsFalse()
+        {
+            var rootDirectory = CreateTempDirectory();
+            var nestedDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory, "a", "b"));
+
+            var found = GitRepositoryDetector.TryFindGitRoot(nestedDirectory.FullName, out var resolvedRoot);
+
+            Assert.IsFalse(found);
+            Assert.IsNull(resolvedRoot);
+        }
+
+        private static string CreateTempDirectory()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "WorkspaceFilesTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
         private static void SeedStatusCache(string filePath, GitFileStatus status)
         {
             var serviceType = typeof(GitStatusService);


### PR DESCRIPTION
fix #51 - add a .git file detector, as an alternative to the .git diectory for root

doc for the feature is here: https://git-scm.com/docs/git-worktree#_details